### PR TITLE
[ADD] command line tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+install:
+	swift package update
+	swift build -c release
+	install .build/Release/SplashObjcHTMLGen /usr/local/bin/SplashObjcHTMLGen
+	install .build/Release/SplashObjcImageGen /usr/local/bin/SplashObjcImageGen
+	install .build/Release/SplashObjcTokenizer /usr/local/bin/SplashObjcTokenizer

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,18 @@ let package = Package(
         .target(
             name: "SplashObjc",
             dependencies: ["Splash"]),
+        .target(
+            name: "SplashObjcHTMLGen",
+            dependencies: ["SplashObjc", "Splash"]
+        ),
+        .target(
+            name: "SplashObjcImageGen",
+            dependencies: ["SplashObjc", "Splash"]
+        ),
+        .target(
+            name: "SplashObjcTokenizer",
+            dependencies: ["SplashObjc", "Splash"]
+        ),
         .testTarget(
             name: "SplashObjcTests",
             dependencies: ["SplashObjc"]),

--- a/Sources/SplashObjcHTMLGen/main.swift
+++ b/Sources/SplashObjcHTMLGen/main.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Splash
+import SplashObjc
+
+guard CommandLine.arguments.count > 1 else {
+    print("⚠️  Please supply the code to generate HTML for as a string argument")
+    exit(1)
+}
+
+let code = CommandLine.arguments[1]
+let highlighter = SyntaxHighlighter(format: HTMLOutputFormat(), grammar: ObjcGrammar())
+print(highlighter.highlight(code))

--- a/Sources/SplashObjcImageGen/Extensions/CGImage+WriteToURL.swift
+++ b/Sources/SplashObjcImageGen/Extensions/CGImage+WriteToURL.swift
@@ -1,0 +1,19 @@
+/**
+ *  Splash
+ *  Copyright (c) John Sundell 2018
+ *  MIT license - see LICENSE.md
+ */
+
+#if os(macOS)
+
+import Foundation
+
+extension CGImage {
+    func write(to url: URL) {
+        let destination = CGImageDestinationCreateWithURL(url as CFURL, kUTTypePNG, 1, nil)!
+        CGImageDestinationAddImage(destination, self, nil)
+        CGImageDestinationFinalize(destination)
+    }
+}
+
+#endif

--- a/Sources/SplashObjcImageGen/Extensions/CommandLine+Options.swift
+++ b/Sources/SplashObjcImageGen/Extensions/CommandLine+Options.swift
@@ -1,0 +1,61 @@
+/**
+ *  Splash
+ *  Copyright (c) John Sundell 2018
+ *  MIT license - see LICENSE.md
+ */
+
+#if os(macOS)
+
+import Foundation
+import Splash
+
+extension CommandLine {
+    struct Options {
+        let code: String
+        let outputURL: URL
+        let padding: CGFloat
+        let font: Font
+    }
+
+    static func makeOptions() -> Options? {
+        guard arguments.count > 2 else {
+            return nil
+        }
+
+        let defaults = UserDefaults.standard
+
+        return Options(
+            code: arguments[1],
+            outputURL: resolveOutputURL(),
+            padding: CGFloat(defaults.int(forKey: "p", default: 20)),
+            font: resolveFont(from: defaults)
+        )
+    }
+
+    private static func resolveOutputURL() -> URL {
+        let path = arguments[2] as NSString
+        return URL(fileURLWithPath: path.expandingTildeInPath)
+    }
+
+    private static func resolveFont(from defaults: UserDefaults) -> Font {
+        let size = Double(defaults.int(forKey: "s", default: 20))
+
+        guard let path = defaults.string(forKey: "f") else {
+            return Font(size: size)
+        }
+
+        return Font(path: path, size: size)
+    }
+}
+
+private extension UserDefaults {
+    func int(forKey key: String, default: CGFloat) -> CGFloat {
+        guard value(forKey: key) != nil else {
+            return `default`
+        }
+
+        return CGFloat(integer(forKey: key))
+    }
+}
+
+#endif

--- a/Sources/SplashObjcImageGen/Extensions/NSGraphicsContext+Fill.swift
+++ b/Sources/SplashObjcImageGen/Extensions/NSGraphicsContext+Fill.swift
@@ -1,0 +1,18 @@
+/**
+ *  Splash
+ *  Copyright (c) John Sundell 2018
+ *  MIT license - see LICENSE.md
+ */
+
+#if os(macOS)
+
+import Cocoa
+
+extension NSGraphicsContext {
+    func fill(with color: NSColor, in rect: CGRect) {
+        cgContext.setFillColor(color.cgColor)
+        cgContext.fill(rect)
+    }
+}
+
+#endif

--- a/Sources/SplashObjcImageGen/Extensions/NSGraphicsContext+InitWithSize.swift
+++ b/Sources/SplashObjcImageGen/Extensions/NSGraphicsContext+InitWithSize.swift
@@ -1,0 +1,31 @@
+/**
+ *  Splash
+ *  Copyright (c) John Sundell 2018
+ *  MIT license - see LICENSE.md
+ */
+
+#if os(macOS)
+
+import Cocoa
+
+extension NSGraphicsContext {
+    convenience init(size: CGSize) {
+        let scale: CGFloat = 2
+
+        let context = CGContext(
+            data: nil,
+            width: Int(size.width * scale),
+            height: Int(size.height * scale),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+        )!
+
+        context.scaleBy(x: scale, y: scale)
+
+        self.init(cgContext: context, flipped: false)
+    }
+}
+
+#endif

--- a/Sources/SplashObjcImageGen/main.swift
+++ b/Sources/SplashObjcImageGen/main.swift
@@ -1,0 +1,51 @@
+#if os(macOS)
+
+import Cocoa
+import Splash
+import SplashObjc
+
+guard let options = CommandLine.makeOptions() else {
+    print("""
+    ⚠️  Two arguments are required:
+    - The code to generate an image for
+    - The path to write the generated image to
+
+    Optionally, the following arguments can be passed:
+    -p The amount of padding (in pixels) to apply around the code
+    -f A path to a font to use when rendering
+    -s The size of text to use when rendering
+    """)
+    exit(1)
+}
+
+let theme = Theme.sundellsColors(withFont: options.font)
+let outputFormat = AttributedStringOutputFormat(theme: theme)
+let highlighter = SyntaxHighlighter(format: outputFormat, grammar: ObjcGrammar())
+let string = highlighter.highlight(options.code)
+let stringSize = string.size()
+
+let contextRect = CGRect(
+    x: 0,
+    y: 0,
+    width: stringSize.width + options.padding * 2,
+    height: stringSize.height + options.padding * 2
+)
+
+let context = NSGraphicsContext(size: contextRect.size)
+NSGraphicsContext.current = context
+
+context.fill(with: theme.backgroundColor, in: contextRect)
+
+string.draw(in: CGRect(
+    x: options.padding,
+    y: options.padding,
+    width: stringSize.width,
+    height: stringSize.height
+))
+
+let image = context.cgContext.makeImage()!
+image.write(to: options.outputURL)
+
+#else
+print("😞 SplashImageGen currently only supports macOS")
+#endif

--- a/Sources/SplashObjcTokenizer/TokenizerOutputFormat.swift
+++ b/Sources/SplashObjcTokenizer/TokenizerOutputFormat.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Splash
+
+struct TokenizerOutputFormat: OutputFormat {
+    func makeBuilder() -> Builder {
+        return Builder()
+    }
+}
+
+extension TokenizerOutputFormat {
+    struct Builder: OutputBuilder {
+        private var components = [String]()
+
+        mutating func addToken(_ token: String, ofType type: TokenType) {
+            components.append("\(type.string.capitalized) token: \(token)")
+        }
+
+        mutating func addPlainText(_ text: String) {
+            components.append("Plain text: \(text)")
+        }
+
+        mutating func addWhitespace(_ whitespace: String) {
+            // Ignore whitespace
+        }
+
+        func build() -> String {
+            return components.joined(separator: "\n")
+        }
+    }
+}

--- a/Sources/SplashObjcTokenizer/main.swift
+++ b/Sources/SplashObjcTokenizer/main.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Splash
+import SplashObjc
+
+guard CommandLine.arguments.count > 1 else {
+    print("⚠️  Please supply the code to tokenize as a string argument")
+    exit(1)
+}
+
+let code = CommandLine.arguments[1]
+let highlighter = SyntaxHighlighter(format: TokenizerOutputFormat(), grammar: ObjcGrammar())
+print(highlighter.highlight(code))


### PR DESCRIPTION
Adding command line tools port to Objc from splash original project.
These are basically the same as Swift Splash tools, but with the objc grammar.
Thanks to John Sundell for the work making the original version of these

https://github.com/JohnSundell/Splash/