### PR TITLE
Add support for typedef and blocks

### DIFF
--- a/Sources/SplashObjc/ObjcGrammar.swift
+++ b/Sources/SplashObjc/ObjcGrammar.swift
@@ -34,9 +34,9 @@ public struct ObjcGrammar: Grammar {
     static let keywords: Set<String> = [
         "static", "const",
 
-        //Primitive types
+        //Types
         "int", "double", "float", "char", "struct", "void", "BOOL",
-        "instancetype", "id", "long", "short", "unsigned",
+        "instancetype", "id", "long", "short", "unsigned", "typedef",
 
         //Objc runtime
         "SEL", "IMP", "@selector",
@@ -46,7 +46,7 @@ public struct ObjcGrammar: Grammar {
 
         //----
         "nonatomic", "atomic", "readwrite", "readonly", "assign", "copy",
-        "nullable", "nonnull", "strong", "weak", "unsafe_unretained",
+        "nullable", "nonnull", "strong", "weak", "unsafe_unretained", "_Nonnull",
 
         //---
         "self", "super",
@@ -283,6 +283,10 @@ public struct ObjcGrammar: Grammar {
             //Prevents comments right after punctuation to be merged with the punctuation.
             //In the following line of code, ;// would be merged together as plainText otherwise
             //int n = 5;// number
+            return false
+        case (":", "^"):
+            //Prevents : and ^ from being merged when passing a block as a method argument
+            //[someObject someMethodThatTakesABlock:^ReturnType (parameters) {...}];
             return false
         default:
             return true

--- a/Tests/SplashObjcTests/BlocksTests.swift
+++ b/Tests/SplashObjcTests/BlocksTests.swift
@@ -1,0 +1,8 @@
+//
+//  BlocksTests.swift
+//  
+//
+//  Created by Marco Capano on 05/04/2020.
+//
+
+import Foundation

--- a/Tests/SplashObjcTests/BlocksTests.swift
+++ b/Tests/SplashObjcTests/BlocksTests.swift
@@ -3,6 +3,143 @@
 //  
 //
 //  Created by Marco Capano on 05/04/2020.
+//  I of course do not remember all the ways you can declare a block in Objective-C.
+//  Luckily http://fuckingblocksyntax.com exists ❤️
 //
 
-import Foundation
+import XCTest
+import Splash
+@testable import SplashObjc
+
+class BlocksTests: XCTestCase {
+    private(set) var highlighter: SyntaxHighlighter<OutputFormatMock>!
+    private(set) var builder: OutputBuilderMock!
+
+    override func setUp() {
+        super.setUp()
+        builder = OutputBuilderMock()
+
+        let format = OutputFormatMock(builder: builder)
+        highlighter = SyntaxHighlighter(format: format, grammar: ObjcGrammar())
+    }
+
+    func testBlockAsLocalVariable() {
+        let components = highlighter.highlight("""
+        void (^blockName)(ParameterType parameter) = ^(ParameterType parameter) {
+            [parameter doStuff];
+        };
+        """)
+
+        XCTAssertEqual(components, [
+            .token("void", .keyword),
+            .whitespace(" "),
+            .plainText("(^blockName)("),
+            .token("ParameterType", .type),
+            .whitespace(" "),
+            .plainText("parameter)"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .plainText("^("),
+            .token("ParameterType", .type),
+            .whitespace(" "),
+            .plainText("parameter)"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .plainText("[parameter"),
+            .whitespace(" "),
+            .token("doStuff", .call),
+            .plainText("];"),
+            .whitespace("\n"),
+            .plainText("};")
+        ])
+    }
+
+    func testBlockAsAProperty() {
+        let components = highlighter.highlight("""
+        @property (nonatomic, copy) void (^blockName)(ParameterType);
+        """)
+
+        XCTAssertEqual(components, [
+            .token("@property", .keyword),
+            .whitespace(" "),
+            .plainText("("),
+            .token("nonatomic", .keyword),
+            .plainText(","),
+            .whitespace(" "),
+            .token("copy", .keyword),
+            .plainText(")"),
+            .whitespace(" "),
+            .token("void", .keyword),
+            .whitespace(" "),
+            .plainText("(^blockName)("),
+            .token("ParameterType", .type),
+            .plainText(");")
+        ])
+    }
+
+    func testBlockAsAMethodParameter() {
+        let components = highlighter.highlight("""
+        - (void)someMethodThatTakesABlock:(ReturnType (^_Nonnull)(ParameterType))blockName;
+        """)
+
+        XCTAssertEqual(components, [
+            .plainText("-"),
+            .whitespace(" "),
+            .plainText("("),
+            .token("void", .keyword),
+            .plainText(")someMethodThatTakesABlock:("),
+            .token("ReturnType", .type),
+            .whitespace(" "),
+            .plainText("(^"),
+            .token("_Nonnull", .keyword),
+            .plainText(")("),
+            .token("ParameterType", .type),
+            .plainText("))blockName;")
+        ])
+    }
+
+    func testBlockAsAnArgumentToAMethodCall() {
+        let components = highlighter.highlight("""
+        [someObject someMethodThatTakesABlock:^ReturnType (NSString *s) {
+            //stuff
+        }];
+        """)
+
+        XCTAssertEqual(components, [
+            .plainText("[someObject"),
+            .whitespace(" "),
+            .token("someMethodThatTakesABlock", .call),
+            .plainText(":^"),
+            .token("ReturnType", .type),
+            .whitespace(" "),
+            .plainText("("),
+            .token("NSString", .type),
+            .whitespace(" "),
+            .plainText("*s)"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("//stuff", .comment),
+            .whitespace("\n"),
+            .plainText("}];")
+        ])
+    }
+
+    func testAsTypedef() {
+        let components = highlighter.highlight("typedef void (^CompletionHandler)(void);")
+
+        XCTAssertEqual(components, [
+            .token("typedef", .keyword),
+            .whitespace(" "),
+            .token("void", .keyword),
+            .whitespace(" "),
+            .plainText("(^"),
+            .token("CompletionHandler", .type),
+            .plainText(")("),
+            .token("void", .keyword),
+            .plainText(");")
+        ])
+    }
+}


### PR DESCRIPTION
Adding support for new keyword, `typedef` and tests for blocks.
Blocks apparently won’t  need special rules